### PR TITLE
feat: Add Playwright end-to-end testing setup and test cases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,62 @@
+name: E2E Tests (Playwright)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install Python dependencies
+        run: |
+          poetry --version
+          poetry install --no-interaction --no-ansi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers and deps
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        env:
+          CI: true
+        run: npm test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,10 @@ __marimo__/
 
 # VS Code
 .vscode
+
+# Node
+node_modules/
+
+# Playwright
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # book-lamp
 
 Using `colima` for local docker management.
+# TODO stop and start automatically
+
+## End-to-end tests (Playwright)
+
+Install Node dependencies once:
+
+```bash
+npm ci
+npx playwright install --with-deps
+```
+
+Run the E2E suite (starts the app automatically):
+
+```bash
+npm test
+```
+
+Headed mode:
+
+```bash
+npm run test:ui
+```
+
+Artifacts (screenshots/videos/traces) are saved under `playwright-report/` and `test-results/`.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
+node = "20"
 python = "latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,300 @@
+{
+    "name": "book-lamp-e2e",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "book-lamp-e2e",
+            "version": "0.0.0",
+            "devDependencies": {
+                "@playwright/test": "^1.48.0",
+                "ts-node": "^10.9.2",
+                "typescript": "^5.6.3"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+            "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.56.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+            "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "undici-types": "~7.14.0"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/playwright": {
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+            "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.56.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+            "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+            "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "book-lamp-e2e",
+    "private": true,
+    "version": "0.0.0",
+    "scripts": {
+        "test": "playwright test",
+        "test:ui": "playwright test --ui",
+        "codegen": "playwright codegen http://localhost:5000"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 5000;
+const BASE_URL = process.env.BASE_URL || `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+    testDir: './tests-e2e',
+    globalSetup: require.resolve('./tests-e2e/global.setup'),
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 2 : undefined,
+    reporter: [['html', { open: 'never' }], ['list']],
+    use: {
+        baseURL: BASE_URL,
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+    },
+    webServer: {
+        command: `TEST_MODE=1 FLASK_DEBUG=false FLASK_APP=app.py DB_URL=sqlite:///e2e_test.db poetry run flask run --port ${PORT} --host 127.0.0.1`,
+        url: BASE_URL,
+        timeout: 60_000,
+        reuseExistingServer: !process.env.CI,
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+});
+
+

--- a/tests-e2e/auth.spec.ts
+++ b/tests-e2e/auth.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('auth guard redirects to unauthorized when not logged in', async ({ page }) => {
+    await page.goto('/about');
+    await expect(page).toHaveURL(/.*unauthorized/);
+    await expect(page.getByRole('heading', { name: 'Unauthorized' })).toBeVisible();
+});
+
+test('auth guard allows access after test login', async ({ page }) => {
+    await page.goto('/test/login');
+    await page.goto('/about');
+    await expect(page.locator('text=This is a simple Flask web application.')).toBeVisible();
+});
+
+

--- a/tests-e2e/books.spec.ts
+++ b/tests-e2e/books.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page, request }) => {
+    await request.post('/test/reset');
+    await page.goto('/test/login');
+});
+
+test('books list initially empty and link to add', async ({ page }) => {
+    await page.goto('/books');
+    await expect(page.getByRole('heading', { name: 'Books' })).toBeVisible();
+    await expect(page.locator('text=No books yet.')).toBeVisible();
+    await page.getByRole('link', { name: 'Add one' }).click();
+    await expect(page).toHaveURL(/.*\/books\/new/);
+});
+
+test('adding invalid ISBN shows error', async ({ page }) => {
+    await page.goto('/books/new');
+    await page.fill('#isbn', '123');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.locator('.messages .error', { hasText: 'valid 13-digit ISBN' })).toBeVisible();
+});
+
+test('adding duplicate shows info message', async ({ page }) => {
+    await page.goto('/books/new');
+    await page.fill('#isbn', '9780000000000');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page).toHaveURL(/.*\/books$/);
+    await expect(page.locator('.messages .success', { hasText: 'Book added successfully' })).toBeVisible();
+
+    await page.goto('/books/new');
+    await page.fill('#isbn', '9780000000000');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.locator('.messages .info', { hasText: 'already been added' })).toBeVisible();
+});
+
+test('successful add shows on list with metadata', async ({ page }) => {
+    await page.goto('/books/new');
+    await page.fill('#isbn', '9780000000000');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await expect(page.locator('.messages .success', { hasText: 'Book added successfully' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Books' })).toBeVisible();
+    await expect(page.locator('.card .title', { hasText: 'Test Driven Development' })).toBeVisible();
+    await expect(page.locator('.card .author', { hasText: 'Test Author' })).toBeVisible();
+    await expect(page.locator('.card .year', { hasText: '2019' })).toBeVisible();
+    await expect(page.locator('.card .isbn', { hasText: '9780000000000' })).toBeVisible();
+});
+
+

--- a/tests-e2e/global.setup.ts
+++ b/tests-e2e/global.setup.ts
@@ -1,0 +1,13 @@
+import { request } from '@playwright/test';
+
+export default async function globalSetup() {
+    const baseURL = process.env.BASE_URL || 'http://127.0.0.1:5000';
+    const req = await request.newContext({ baseURL });
+    const res = await req.post('/test/reset');
+    if (!res.ok()) {
+        throw new Error(`Failed to reset DB: ${res.status()}`);
+    }
+    await req.dispose();
+}
+
+

--- a/tests-e2e/home.spec.ts
+++ b/tests-e2e/home.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ request }) => {
+    // Ensure DB is reset before each test file, idempotent
+    await request.post('/test/reset');
+});
+
+test('home page shows logged-out state, then login works in TEST_MODE', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=You are not logged in.')).toBeVisible();
+    await page.getByRole('link', { name: 'Login with Google' }).click();
+    await expect(page.locator('text=Hello Test User!')).toBeVisible();
+    await page.getByRole('link', { name: 'Logout' }).click();
+    await expect(page.locator('text=You are not logged in.')).toBeVisible();
+});
+
+


### PR DESCRIPTION
- Introduced Playwright for end-to-end testing, including configuration in playwright.config.ts.
- Created test scripts for authentication and book management features.
- Implemented test utilities in app.py for deterministic testing in TEST_MODE.
- Updated README.md with instructions for running end-to-end tests.
- Added GitHub Actions workflow for automated E2E testing on push and pull requests.
- Updated .gitignore to exclude Playwright report and test results directories.