### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
   lint-and-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/kchapl/book-lamp/security/code-scanning/1](https://github.com/kchapl/book-lamp/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block for each job (or at the workflow root) so the `GITHUB_TOKEN` has only the scopes needed. Here, only the `lint-and-format` job is missing such a block; the `test` job already uses `contents: read` and `checks: write`, and `e2e` is disabled (`if: false`), so we only need to update `lint-and-format`.

The best minimal fix without changing functionality is to add a `permissions` section under `lint-and-format:` setting `contents: read`. That matches what CodeQL suggests and is sufficient for typical CI tasks involving `actions/checkout` and reading the repository. No new imports or dependencies are required, and no steps need modification.

Concretely, in `.github/workflows/ci.yml`, under the `lint-and-format` job definition (around line 63), insert:

```yaml
  lint-and-format:
    runs-on: ubuntu-latest
    permissions:
      contents: read
```

leaving the rest of the job’s steps unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
