### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/book_lamp/app.py
+++ b/book_lamp/app.py
@@ -148,13 +148,13 @@ def login():
 
         app.logger.info(f"Initiating OAuth flow with redirect_uri: {redirect_uri}")
         return oauth.google.authorize_redirect(redirect_uri)
-    except Exception as e:
+    except Exception:
         app.logger.exception("OAuth login failed")
         return (
-            f"<h1>Login Error</h1>"
-            f"<p>Failed to initiate Google OAuth login.</p>"
-            f"<p>Please check that GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are set correctly.</p>"
-            f"<a href='/'>Go back</a>"
+            "<h1>Login Error</h1>"
+            "<p>Failed to initiate Google OAuth login.</p>"
+            "<p>Please check that GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are set correctly.</p>"
+            "<a href='/'>Go back</a>"
         ), 500
 
 
@@ -187,12 +187,10 @@ def authorize():
 
         flash("Successfully authorized Google Sheets access!", "success")
         return redirect(url_for("home"))
-    except Exception as e:
+    except Exception:
         app.logger.exception("Failed to authorize access token")
         return (
-            f"<h1>Authorization Error</h1>"
-            f"<p>Failed to complete Google OAuth authorization.</p>"
-            f"<a href='/'>Go back</a>"
+            "<h1>Authorization Error</h1><p>Failed to complete Google OAuth authorization.</p><a href='/'>Go back</a>"
         ), 401
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/kchapl/book-lamp/security/code-scanning/4](https://github.com/kchapl/book-lamp/security/code-scanning/4)

To fix this, the detailed exception information (`str(e)`) must no longer be sent back to the client, while still being logged on the server. The general approach is: keep or improve the server-side logging (which can include the full exception and traceback), but change the user-facing HTML to a generic error message that does not include `e` or any stack/trace details.

Concretely, in `book_lamp/app.py`:

- In the `/login` route, keep the `app.logger.error(...)` call, but remove `str(e)` from the HTML response. Replace the response body with a generic explanation (for example, that login failed, and that environment variables may be misconfigured) without interpolating the actual exception text. Alternatively, log with `app.logger.exception(...)` to capture the stack trace while still sending a generic message to the user.
- In the `/authorize` route, do the same: keep logging the detailed error (`str(e)` or using `logger.exception`), but change the returned HTML to omit `str(e)` and just say that authorization failed.

No new imports are strictly required. If desired, `app.logger.exception` can be used instead of `app.logger.error` to automatically include the traceback; this does not require any imports.

The precise changes:

- Around line 151–159 (`login` function): adjust the `app.logger.error` call optionally to `app.logger.exception` and remove `{str(e)}` from the returned HTML. The message about `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can remain because it refers only to configuration keys, not values.
- Around line 191–198 (`authorize` function): similarly, optionally change `logger.error` to `logger.exception` and remove `{str(e)}` from the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
