### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/book_lamp/app.py
+++ b/book_lamp/app.py
@@ -390,7 +390,8 @@ if TEST_MODE:
             storage.next_record_id = 1
             return {"status": "ok"}
         except Exception as e:
-            return {"status": "error", "message": str(e)}, 500
+            app.logger.exception("Failed to reset test storage: %s", e)
+            return {"status": "error", "message": "Internal error during test reset"}, 500
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/kchapl/book-lamp/security/code-scanning/6](https://github.com/kchapl/book-lamp/security/code-scanning/6)

In general, to fix this kind of issue you should avoid sending raw exception details (messages or stack traces) back to clients. Instead, log the exception on the server for debugging/monitoring purposes, and return a generic, user-safe error message.

For this specific case in `book_lamp/app.py`, the best targeted fix is:

- In the `/test/reset` handler, keep the try/except structure but:
  - Log the exception using the existing `app.logger` (Flask provides this).
  - Replace `str(e)` in the returned JSON with a generic message like `"Internal error during test reset"` so no internal details are exposed.
- No other behavior needs to change: it should still return HTTP 500 on failure and `"status": "error"` for the caller.

Concretely, in `book_lamp/app.py`, around lines 386–393:

- Replace  
  `return {"status": "error", "message": str(e)}, 500`  
  with something like:  
  `app.logger.exception("Failed to reset test storage")` (or `error` if you prefer) followed by  
  `return {"status": "error", "message": "Internal error during test reset"}, 500`.

No new imports are required because `app.logger` is already available via Flask, and `logging` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
