### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
   e2e:
     if: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/kchapl/book-lamp/security/code-scanning/2](https://github.com/kchapl/book-lamp/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that limits the `GITHUB_TOKEN` privileges for the `e2e` job. The minimal recommended scope for this job is `contents: read`, since it needs to check out code and possibly use other read-only operations, but does not appear to require writing to the repository or modifying pull requests.

Concretely, in `.github/workflows/ci.yml`, under the `e2e:` job definition (around line 107), insert a `permissions:` section similar to what you already have for the `lint-and-format` job. This preserves existing functionality, because the job is currently disabled (`if: false`) and even if later enabled, the steps use standard actions that work with read-only contents permissions. No additional imports, methods, or definitions are required—this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
